### PR TITLE
Fix incorrect font path

### DIFF
--- a/resources/views/quran/page/show.blade.php
+++ b/resources/views/quran/page/show.blade.php
@@ -231,7 +231,8 @@ style tag messed up the syntax highlighting. --}}
         @foreach ($fonts as $font)
             @font-face {
                 font-family: '{{ $font }}';
-                src: url('{{ asset('quran-fonts/fonts/King Fahd Complex/Original/Hafs-QCF4/' . $font . '.woff2') }}') format('woff2');
+                src: url('{{ asset('quran-fonts/fonts/King Fahd Complex/Original/Hafs-QCF4/woff2/' . $font . '.woff2') }}') format('woff2'),
+                    url('{{ asset('quran-fonts/fonts/King Fahd Complex/Original/Hafs-QCF4/' . $font . '.ttf') }}') format('truetype');
             }
 
             @font-face {

--- a/resources/views/quran/surah/show.blade.php
+++ b/resources/views/quran/surah/show.blade.php
@@ -172,9 +172,10 @@ style tag messed up the syntax highlighting. --}}
         /* Struggle juga nak buat ni. Ok first, load font yang mana akan digunakan */
 
         @foreach ($fonts as $font)
-            @font-face {
+        @font-face {
                 font-family: '{{ $font }}';
-                src: url('{{ asset('quran-fonts/fonts/King Fahd Complex/Original/Hafs-QCF4/' . $font . '.woff2') }}') format('woff2');
+                src: url('{{ asset('quran-fonts/fonts/King Fahd Complex/Original/Hafs-QCF4/woff2/' . $font . '.woff2') }}') format('woff2'),
+                    url('{{ asset('quran-fonts/fonts/King Fahd Complex/Original/Hafs-QCF4/' . $font . '.ttf') }}') format('truetype');
             }
 
             @font-face {


### PR DESCRIPTION
The text wouldn't load because it cannot find the font specified

![image](https://github.com/user-attachments/assets/393250d1-0d66-4d6e-b1c3-b2bf0bb8b798)


Now with this PR, it is fixed

![image](https://github.com/user-attachments/assets/4d1f959c-ad93-4bf8-b4e6-6af5f3581689)
